### PR TITLE
Allow for ajax/jsonp results from the /raw url.

### DIFF
--- a/datagrepper/__init__.py
+++ b/datagrepper/__init__.py
@@ -141,6 +141,9 @@ def raw():
     page = int(flask.request.args.get('page', 1))
     rows_per_page = int(flask.request.args.get('rows_per_page', 20))
 
+    # Response formatting arguments
+    callback = flask.request.args.get('callback', None)
+
     arguments = dict(
         start=datetime_to_seconds(start),
         delta=timedelta_to_seconds(delta),
@@ -193,10 +196,17 @@ def raw():
         status = "500 error"
 
     body = fedmsg.encoding.dumps(output)
+
+    mimetype = 'application/json'
+
+    if callback:
+        mimetype = 'application/javascript'
+        body = "%s(%s);" % (callback, body)
+
     return flask.Response(
         response=body,
         status=status,
-        mimetype='application/json',
+        mimetype=mimetype,
     )
 
 


### PR DESCRIPTION
@pypingou wants to make ajax calls to datagrepper (which makes sense to me).  In order to do that, datagrepper needs to be able to return JSONP data as well as just JSON.

http://stackoverflow.com/questions/3240889/json-response-from-jquery-get-raises-invalid-label
