### PR TITLE
Call __json__ on the Message instance, not the class.

### DIFF
--- a/datagrepper/app.py
+++ b/datagrepper/app.py
@@ -260,7 +260,7 @@ def raw():
         )
 
         # Convert our messages from sqlalchemy objects to json-like dicts
-        messages = map(dm.Message.__json__, messages)
+        messages = [msg.__json__() for msg in messages]
 
         if meta:
             for message in messages:


### PR DESCRIPTION
Message.**json** is currently getting called as if it were a classmethod, but that is not the case. This patch calls the **json** method on the Message instances instead. :neckbeard: 
