### PR TITLE
Fix lockfile import for el6 version of lockfile

### DIFF
--- a/datagrepper/runner.py
+++ b/datagrepper/runner.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 import fedmsg
 import fedmsg.consumers
-from lockfile import LockFile
+try:
+    from lockfile import LockFile
+except ImportError:
+    from lockfile import FileLock as LockFile
 import os
 
 from datagrepper.app import app, db


### PR DESCRIPTION
This commit is running as a hotfix on datagrepper01.stg currently.

lockfile apparently renamed their main class from `FileLock` to `LockFile` after the version currently in el6, so this handles that.
