### PR TITLE
Fix widget css resources paths.

### DIFF
--- a/datagrepper/default_config.py
+++ b/datagrepper/default_config.py
@@ -1,0 +1,1 @@
+APP_PATH = 'https://apps.fedoraproject.org/datagrepper'

--- a/datagrepper/widgets.py
+++ b/datagrepper/widgets.py
@@ -107,8 +107,7 @@ def widget_js():
 
     if flask.request.args.get('css', '').lower() == 'true':
         def static_url(filename):
-            default = "https://apps.fedoraproject.org/datagrepper"
-            return app.config.get('APP_PATH', default) + "/static/" + filename
+            return app.config['APP_PATH'] + "/static/" + filename
 
         css.append(css_helper % static_url('css/bootstrap.css'))
         css.append(css_helper % static_url('css/raw.css'))


### PR DESCRIPTION
I played with this a bunch in staging but I couldn't get it to work
using Flask's SERVER_NAME (which seems to be the way it is supposed to
work with url_for).  This way is just as easy, and it works (unlike
url_for).
