### PR TITLE
Optimize count_all_messages()

### DIFF
--- a/datagrepper/app.py
+++ b/datagrepper/app.py
@@ -192,7 +192,7 @@ def count_all_messages():
         query = "SELECT reltuples FROM pg_class WHERE relname = 'messages';"
         total = dm.session.execute(query).first()[0]
     else:
-        total = dm.Message.grep()[0]
+        total = dm.Message.grep(defer=True)[0]
 
     return total
 


### PR DESCRIPTION
When counting the exact number of messages, `dm.Message.grep()[0]` is used to
get the total. Since no arguments are given, no filters are added to the
`Message.query`. However, with the default `defer=True` argument, the grep method
returns the total count, the number of pages, and `Message.query.all()`.
Thankfully, we can pass `defer=True` and it won't call `all()` on the query.

:warning: untested :construction: 
