### PR TITLE
Expand container-narrow div from 700px to 800px to fit 8-digit request counts for the js counter.

### DIFF
--- a/datagrepper/templates/index.html
+++ b/datagrepper/templates/index.html
@@ -20,7 +20,7 @@
       /* Custom container */
       .container-narrow {
         margin: 0 auto;
-        max-width: 700px;
+        max-width: 800px;
       }
       .container-narrow > hr {
         margin: 30px 0;


### PR DESCRIPTION
This simple tweak resolves the current issue on the datagrepper site where the now-in-10-millions requests counter is broken into two lines. Tested only with the Firefox web editor but I'm pretty sure we're safe. Just submitting a PR since it's not my project. :baby: 
