### PR TITLE
Hide charts for now.

### DIFF
--- a/datagrepper/templates/index.html
+++ b/datagrepper/templates/index.html
@@ -77,7 +77,7 @@
         <ul class="nav nav-pills pull-right">
           <li{% if request.endpoint == 'index' %} class="active"{% endif %}><a href="{{ url_for('index') }}">Getting started</a></li>
           <li><a href="{{ url_for('raw') }}">Feed</a></li>
-          <li{% if request.endpoint == 'charts' %} class="active"{% endif %}><a href="{{ url_for('charts') }}">Charts</a></li>
+          <!-- <li{% if request.endpoint == 'charts' %} class="active"{% endif %}><a href="{{ url_for('charts') }}">Charts</a></li> -->
           <li{% if request.endpoint == 'reference' %} class="active"{% endif %}><a href="{{ url_for('reference') }}">Reference</a></li>
           <li{% if request.endpoint == 'widget' %} class="active"{% endif %}><a href="{{ url_for('widget') }}">Embedding</a></li>
           <li><a href="https://github.com/fedora-infra/datagrepper">Source</a></li>


### PR DESCRIPTION
These are deployed in staging, and they work, but they are too slow to
be useful.  Let's hide them for now until we can come up with a better
solution for the database.
