### PR TITLE
Be more explicit with Content-Security-Policy.

### DIFF
--- a/datagrepper/templates/base.html
+++ b/datagrepper/templates/base.html
@@ -8,7 +8,7 @@
     <meta name="author" content="Ralph Bean">
 
     <!-- Only allow websockets connections to fedoraproject.org. -->
-    <meta http-equiv="Content-Security-Policy" content="connect-src '*.fedoraproject.org'">
+    <meta http-equiv="Content-Security-Policy" content="connect-src https://*.fedoraproject.org wss://*.fedoraproject.org">
 
     <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.png') }}">
 

--- a/datagrepper/templates/index.html
+++ b/datagrepper/templates/index.html
@@ -8,7 +8,7 @@
     <meta name="author" content="">
 
     <!-- Only allow websockets connections to fedoraproject.org. -->
-    <meta http-equiv="Content-Security-Policy" content="connect-src '*.fedoraproject.org'">
+    <meta http-equiv="Content-Security-Policy" content="connect-src https://*.fedoraproject.org wss://*.fedoraproject.org">
 
     <!-- Le styles -->
     <link href="static/css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
Firefox was okay with the old version but chrome thought it was invalid
and partially ignored it, and then rejected our ability to load some of
the javascript bits for fedmenu.

This fixes fedora-infra/fedmenu#3.