### PR TITLE
Make the websocket configurable.

### DIFF
--- a/datagrepper/app.py
+++ b/datagrepper/app.py
@@ -83,6 +83,9 @@ def inject_variable():
         extras['fedmenu_url'] = fedmsg_config['fedmenu_url']
         extras['fedmenu_data_url'] = fedmsg_config['fedmenu_data_url']
 
+    if 'websocket_address' in fedmsg_config:
+        extras['websocket_address'] = fedmsg_config['websocket_address']
+
     return extras
 
 

--- a/datagrepper/static/live.js
+++ b/datagrepper/static/live.js
@@ -1,5 +1,4 @@
-
-$(document).ready(function() {
+var setup_websocket = function(socket_url) {
     var pending_count = 0;
 
     function getUrlVars() {
@@ -25,8 +24,6 @@ $(document).ready(function() {
 
         if ("WebSocket" in window) {
             // Let us open a web socket
-            var socket_url = "wss://hub.fedoraproject.org:9939";
-            //var socket_url = "wss://209.132.181.16:9939";
             var ws = new WebSocket(socket_url);
             ws.onopen = function(e) {
                 // Web Socket is connected, send data using send()
@@ -70,4 +67,4 @@ $(document).ready(function() {
             });
         })
     }
-});
+};

--- a/datagrepper/templates/base.html
+++ b/datagrepper/templates/base.html
@@ -83,7 +83,14 @@
     <script src="{{ url_for('static', filename='jquery-2.1.0.min.js') }}"></script>
     {% if autoscroll %}
     <script src="{{ url_for('static', filename='autoscroll.js') }}"></script>
+    {% if websocket_address is defined %}
     <script src="{{ url_for('static', filename='live.js') }}"></script>
+    <script>
+      $(document).ready(function() {
+          setup_websocket("{{websocket_address}}");
+      });
+    </script>
+    {% endif %}
     {% endif %}
 
     {% if fedmenu_url is defined %}

--- a/datagrepper/templates/index.html
+++ b/datagrepper/templates/index.html
@@ -101,6 +101,7 @@
         <span id="odometer" class="odometer centered visible-sm visible-md visible-lg">{{total}}</span>
       </div>
 
+      {% if websocket_address is defined %}
       <script>
           var count = {{total}};
           $(document).ready(function() {
@@ -112,7 +113,7 @@
             if ("WebSocket" in window)
             {
                 // Let us open a web socket
-                var ws = new WebSocket("wss://hub.fedoraproject.org:9939");
+                var ws = new WebSocket("{{ websocket_address }}");
                 ws.onopen = function(e)
                 {
                     // Web Socket is connected, send data using send()
@@ -128,6 +129,7 @@
             }
           }
       </script>
+      {% endif %}
       {% endif %}
 
       <div class="row marketing">

--- a/fedmsg.d/example-datagrepper.py
+++ b/fedmsg.d/example-datagrepper.py
@@ -14,4 +14,6 @@ config = {
     # For development
     #'fedmenu_url': 'http://threebean.org/fedmenu',
     #'fedmenu_data_url': 'http://threebean.org/fedmenu/dev-data.js',
+
+    #'websocket_address': 'wss://hub.fedoraproject.org:9939',
 }


### PR DESCRIPTION
It was hardcoded to phone home to Fedora Infra's infrastructure, but
SDub noticed that his private instance was also phoning home.  We should
let others disable that or point it at their own websocket server.