### PR TITLE
Remove /topics endpoint

### DIFF
--- a/datagrepper/docs/index.rst
+++ b/datagrepper/docs/index.rst
@@ -112,7 +112,7 @@ from oldest to newest.
 Only Bodhi messages (OR wiki)
 -----------------------------
 
-There is a `long list <http://fedmsg.com/en/latest/topics/>`_ of types of
+There is a `long list <http://fedora-fedmsg.rtfd.org/en/latest/topics.html>`_ of types of
 messages that come across the Fedora Infrastructure's message bus.
 You can limit the scope of your query to only one kind of message
 by specifying a ``category``::
@@ -192,7 +192,3 @@ Topics list
 If you don't know what topics are available for you to query, check the `list
 of topics in the documentation
 <https://fedora-fedmsg.readthedocs.org/en/latest/topics.html>`_.
-
-You can also use the ``/topics`` endpoint with no arguments::
-
-    $ http get {{URL}}topics/

--- a/datagrepper/docs/reference.rst
+++ b/datagrepper/docs/reference.rst
@@ -258,10 +258,3 @@ Formatting arguments
 ``is_raw``
   Checks whether the card is coming from /raw url or not. Must be one of either "true" or "false".
   If card is from /raw url then it will be "true" otherwise "false".
-
-/topics
--------
-
-Returns a list of all topics in the datanommer database. Takes no arguments.
-
-This is cached hourly, and it often takes a while to generate.

--- a/development.cfg
+++ b/development.cfg
@@ -1,3 +1,1 @@
 DEBUG = True
-
-DATAGREPPER_CACHE_BACKEND = 'dogpile.cache.memory'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ Flask
 datanommer.models>=0.6.0
 fedmsg>=0.10.0
 docutils
-dogpile.cache
 fedmsg_meta_fedora_infrastructure
 pygal


### PR DESCRIPTION
.. and everything that goes with it.  It never worked, so there's no
reason to keep it around and confuse everybody.  The docs now point
*only* to the fedmsg_meta list of topics, which have lots more
information -- people should be referencing that.

This was the only thing using dogpile.cache, so we can get rid of that as
well.

Fixes #142.