### PR TITLE
Return JSON with tracebacks for internal server errors.

### DIFF
--- a/datagrepper/app.py
+++ b/datagrepper/app.py
@@ -667,3 +667,16 @@ def not_found(error):
         status=404,
         mimetype='application/json',
     )
+
+
+@app.errorhandler(500)
+def internal_error(error):
+    return flask.Response(
+        response=fedmsg.encoding.dumps({
+            'error': 'internal_error',
+            'detail': str(error),
+            'traceback': traceback.format_exc(),
+        }),
+        status=500,
+        mimetype='application/json',
+    )


### PR DESCRIPTION
In a roundabout way, this fixes #143.  It still returns a 500 error code.. but will tell the user why.