### PR TITLE
SQLAlchemy no longer supports py2.6, drop the tests on it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 install: "python setup.py install"
 script: "python setup.py test"


### PR DESCRIPTION
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>