### PR TITLE
Fix two bugs.

### DIFF
--- a/datagrepper/app.py
+++ b/datagrepper/app.py
@@ -39,6 +39,8 @@ import fedmsg
 import fedmsg.meta
 import fedmsg.config
 import datanommer.models as dm
+
+from werkzeug.exceptions import BadRequest
 from moksha.common.lib.converters import asbool
 
 from datagrepper.util import (
@@ -333,13 +335,13 @@ def raw():
     if chrome not in ['true', 'false']:
         raise ValueError("chrome should be either 'true' or 'false'")
 
-    if contains and datetime.fromtimestamp(start) < (datetime.utcnow() - timedelta(weeks=4*8)):
-        raise flask.BadRequest('When using contains, specify a start at most '
-                               'eight months into the past')
+    if contains and datetime.fromtimestamp(start or 0) < (datetime.utcnow() - timedelta(weeks=4*8)):
+        raise BadRequest('When using contains, specify a start at most '
+                         'eight months into the past')
 
     if contains and not (categories or topics):
-        raise flask.BadRequest('When using contains, specify either a topic or'
-                               ' a category as well')
+        raise BadRequest('When using contains, specify either a topic or'
+                         ' a category as well')
 
     try:
         # This fancy classmethod does all of our search for us.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,6 +47,14 @@ class TestAPI(unittest.TestCase):
         resp = self.client.get('/raw?delta=14400&category=wat&contains=foo')
         self.assertEqual(resp.status_code, 200)
 
+    @patch('datagrepper.app.dm.Message.grep', return_value=(0, 0, []))
+    def test_raw_contains_without_delta(self, grep):
+        """ https://github.com/fedora-infra/datagrepper/issues/206 """
+        resp = self.client.get('/raw?category=wat&contains=foo')
+        self.assertEqual(resp.status_code, 400)
+        target = "When using contains, specify a start at most eight months"
+        assert target in resp.data, "%r not in %r" % (target, resp.data)
+
     @patch('datagrepper.app.dm.Message.query', autospec=True)
     def test_id(self, query):
         msg = query.filter_by.return_value.first.return_value


### PR DESCRIPTION
First, the value of `start` could be None here, which causes the error seen in #206.  Furthermore, it turns out that the `flask` module has no `BadRequest` exception there.  It is really in `werkzeug.exceptions`.  Use that.                           
                      
Lastly, this adds a test, which we really should've added in #197 and *really* should've added in #204.                        
