### PR TITLE
add transaction handling

### DIFF
--- a/datagrepper/app.py
+++ b/datagrepper/app.py
@@ -139,6 +139,13 @@ def add_cors(response):
     return response
 
 
+@app.teardown_appcontext
+def remove_session(exc):
+    """Remove the session, which rolls back the transaction in progress. This is safe because Datagrepper
+       never makes modifications to the database."""
+    dm.session.remove()
+
+
 def modify_rst(rst):
     """ Downgrade some of our rst directives if docutils is too old. """
 


### PR DESCRIPTION
Right now, datagrepper uses one long transaction for the life of the
process. This makes database management more difficult (it holds locks),
and it may be causing a memory leak (since sqlalchemy objects are never
released). This change causes the transaction to be rolled back at the
end of every request, and the session to be removed. A new session will
be created and transaction started at the beginning of the next
request.