### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
 install: "python setup.py install"
 script: "python setup.py test"
 notifications:

--- a/datagrepper/app.py
+++ b/datagrepper/app.py
@@ -55,8 +55,8 @@ from pkg_resources import get_distribution
 app = flask.Flask(__name__)
 app.config.from_object('datagrepper.default_config')
 app.config.from_envvar('DATAGREPPER_CONFIG')
-app.config['CORS_DOMAINS'] = map(re.compile, app.config.get('CORS_DOMAINS', []))
-app.config['CORS_HEADERS'] = map(re.compile, app.config.get('CORS_HEADERS', []))
+app.config['CORS_DOMAINS'] = list(map(re.compile, app.config.get('CORS_DOMAINS', [])))
+app.config['CORS_HEADERS'] = list(map(re.compile, app.config.get('CORS_HEADERS', [])))
 
 # Read in the datanommer DB URL from /etc/fedmsg.d/ (or a local fedmsg.d/)
 fedmsg_config = fedmsg.config.load_config()

--- a/datagrepper/templates/base.html
+++ b/datagrepper/templates/base.html
@@ -17,7 +17,7 @@
     <title>Datagrepper</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="{{theme_css_url}}" rel="stylesheet"> -->
+    <link href="{{theme_css_url}}" rel="stylesheet">
     <link href="{{ url_for('static', filename='css/raw.css') }}" rel="stylesheet">
     <style type="text/css">
       div {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,7 +52,7 @@ class TestAPI(unittest.TestCase):
         """ https://github.com/fedora-infra/datagrepper/issues/206 """
         resp = self.client.get('/raw?category=wat&contains=foo')
         self.assertEqual(resp.status_code, 400)
-        target = "When using contains, specify a start at most eight months"
+        target = b"When using contains, specify a start at most eight months"
         assert target in resp.data, "%r not in %r" % (target, resp.data)
 
     @patch('datagrepper.app.dm.Message.query', autospec=True)
@@ -76,5 +76,5 @@ class TestAPI(unittest.TestCase):
         resp = self.client.get('/charts/line')
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.mimetype, 'image/svg+xml')
-        self.assertIn('<svg xmlns:xlink="http://www.w3.org/1999/xlink',
+        self.assertIn(b'<svg xmlns:xlink="http://www.w3.org/1999/xlink',
                       resp.get_data())


### PR DESCRIPTION
Minor tweaks to enable datagrepper to run under Python 3.

Also, remove what looked like an unmatched HTML comment closure in base.html.