### PR TITLE
Add support for running the tests with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 dist
 build
 *.egg
+.tox/
 
 # Sphinx built documentation (for testing docs generation)
 datagrepper/docs/_build/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py{27,36,37}
+skipsdist = True
+
+[testenv]
+usedevelop = True
+setenv =
+    PYTHONPATH={toxinidir}
+commands =
+    python setup.py install
+    python setup.py test
+


### PR DESCRIPTION
The Fedora Infrastructure is trying to converge the way to run tests on tox
to make it easier to integrate with ci.centos.org.
This commit adds support for running the tests with tox for python 2.7, 3.6
(added compared to travis), 3.7.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>