### PR TITLE
fix MANIFEST.in to include everything under datagrepper/static

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,6 @@ include datagrepper/API.rst
 include COPYING
 graft tests
 graft apache
-graft datagrepper/frontend/static
+graft datagrepper/static
 graft datagrepper/docs
 recursive-include datagrepper *.py *.mak *.js *.css *.png *.gif *.html


### PR DESCRIPTION
MANIFEST.in was referencing a non-existent datagrepper/frontend/static
directory, probably because of an earlier refactor. This caused it to
miss required files under datagrepper/static, including all the font
files.