### PR TITLE
Fix tox py27 environment

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,7 @@
 freezegun
 nose
-sphinx
 mock
+
+# Sphinx 2.1 requires Python 3.5 and above
+sphinx < 2.1; python_version < '3.5'
+sphinx; python_version >= '3.5'


### PR DESCRIPTION
Removing sphinx from test requirements fixes following error.

    $ python setup.py test
    running test
    Searching for sphinx
    Reading https://pypi.org/simple/sphinx/
    Downloading https://files.pythonhosted.org/packages/89/1e/64c77...
    Best match: Sphinx 2.1.2
    Processing Sphinx-2.1.2.tar.gz
    Writing /tmp/easy_install-nc9xFD/Sphinx-2.1.2/setup.cfg
    Running Sphinx-2.1.2/setup.py -q bdist_egg --dist-dir ...
    ERROR: Sphinx requires at least Python 3.5 to run.
    error: Setup script exited with 1
    The command "python setup.py test" exited with 1.

Signed-off-by: Lukas Holecek <hluk@email.cz>