### PR TITLE
Fix timezone ambiguity in tests

### DIFF
--- a/datagrepper/util.py
+++ b/datagrepper/util.py
@@ -4,9 +4,9 @@ import arrow
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 import json
-import time
 import fedmsg
 
 
@@ -25,7 +25,7 @@ def json_return(data):
 
 def datetime_to_seconds(dt):
     """ Name this, just because its confusing. """
-    return time.mktime(dt.timetuple())
+    return datetime.timestamp(dt)
 
 
 def timedelta_to_seconds(td):
@@ -57,7 +57,7 @@ def assemble_timerange(start, end, delta):
                 start = float(start)
                 end = start + float(delta)
 
-        end = datetime.fromtimestamp(float(end))
+        end = datetime.fromtimestamp(float(end), tz=timezone.utc)
 
         if start is None:
             delta = timedelta(seconds=float(delta))
@@ -71,13 +71,13 @@ def assemble_timerange(start, end, delta):
         if end is None:
             end = float(now)
 
-        end = datetime.fromtimestamp(float(end))
+        end = datetime.fromtimestamp(float(end), tz=timezone.utc)
 
         if start is None:
             delta = timedelta(seconds=600.0)
             start = datetime_to_seconds(end - delta)
 
-        start = datetime.fromtimestamp(float(start))
+        start = datetime.fromtimestamp(float(start), tz=timezone.utc)
         delta = end - start
 
         # Convert back to seconds for datanommer.models

--- a/tests/test_timerange.py
+++ b/tests/test_timerange.py
@@ -1,82 +1,84 @@
 import unittest
 import datetime
-import time
+
 
 from nose.tools import eq_
 from freezegun import freeze_time
 
 from datagrepper.util import assemble_timerange
 
+utc = datetime.timezone.utc
+
 
 class TestTimerange(unittest.TestCase):
 
-    @freeze_time(datetime.datetime.fromtimestamp(1325376000))
+    @freeze_time(datetime.datetime.fromtimestamp(1325376000, tz=utc))
     def test_none_none_none(self):
         start, end, delta = assemble_timerange(None, None, None)
         eq_(None, start)
         eq_(None, end)
         eq_(None, delta)
 
-    @freeze_time(datetime.datetime.fromtimestamp(1325376000))
+    @freeze_time(datetime.datetime.fromtimestamp(1325376000, tz=utc))
     def test_delta_none_none(self):
         start, end, delta = assemble_timerange(None, None, 5)
         eq_(1325375995.0, start)
         eq_(1325376000.0, end)
         eq_(5, delta)
 
-    @freeze_time(datetime.datetime.fromtimestamp(1325376000))
+    @freeze_time(datetime.datetime.fromtimestamp(1325376000, tz=utc))
     def test_none_start_none(self):
-        start = datetime.datetime.now() - datetime.timedelta(seconds=700)
-        start = time.mktime(start.timetuple())
+        start = datetime.datetime.utcnow() - datetime.timedelta(seconds=700)
+        start = datetime.datetime.timestamp(start)
         start, end, delta = assemble_timerange(start, None, None)
         eq_(1325375300.0, start)
         eq_(1325376000.0, end)
         eq_(700, delta)
 
-    @freeze_time(datetime.datetime.fromtimestamp(1325376000))
+    @freeze_time(datetime.datetime.fromtimestamp(1325376000, tz=utc))
     def test_delta_start_none(self):
-        start = datetime.datetime.now() - datetime.timedelta(seconds=600)
-        start = time.mktime(start.timetuple())
+        start = datetime.datetime.utcnow() - datetime.timedelta(seconds=600)
+        start = datetime.datetime.timestamp(start)
         start, end, delta = assemble_timerange(start, None, 5)
         eq_(1325375400.0, start)
         eq_(1325375405.0, end)
         eq_(5, delta)
 
-    @freeze_time(datetime.datetime.fromtimestamp(1325376000))
+    @freeze_time(datetime.datetime.fromtimestamp(1325376000, tz=utc))
     def test_none_none_end(self):
-        end = datetime.datetime.now() - datetime.timedelta(seconds=600)
-        end = time.mktime(end.timetuple())
+        end = datetime.datetime.utcnow() - datetime.timedelta(seconds=600)
+        end = datetime.datetime.timestamp(end)
         start, end, delta = assemble_timerange(None, end, None)
         eq_(1325374800.0, start)
         eq_(1325375400.0, end)
         eq_(600, delta)
 
-    @freeze_time(datetime.datetime.fromtimestamp(1325376000))
+    @freeze_time(datetime.datetime.fromtimestamp(1325376000, tz=utc))
     def test_delta_none_end(self):
-        end = datetime.datetime.now() - datetime.timedelta(seconds=600)
-        end = time.mktime(end.timetuple())
+        end = datetime.datetime.utcnow() - datetime.timedelta(seconds=600)
+        end = datetime.datetime.timestamp(end)
         start, end, delta = assemble_timerange(None, end, 5)
         eq_(1325375395.0, start)
         eq_(1325375400.0, end)
         eq_(5, delta)
 
-    @freeze_time(datetime.datetime.fromtimestamp(1325376000))
+    @freeze_time(datetime.datetime.fromtimestamp(1325376000, tz=utc))
     def test_none_start_end(self):
-        end = datetime.datetime.now() - datetime.timedelta(seconds=600)
-        end = time.mktime(end.timetuple())
-        start = datetime.datetime.now() - datetime.timedelta(seconds=800)
-        start = time.mktime(start.timetuple())
+        end = datetime.datetime.utcnow() - datetime.timedelta(seconds=600)
+        end = datetime.datetime.timestamp(end)
+        start = datetime.datetime.utcnow() - datetime.timedelta(seconds=800)
+        start = datetime.datetime.timestamp(start)
         start, end, delta = assemble_timerange(start, end, None)
         eq_(1325375200.0, start)
         eq_(1325375400.0, end)
         eq_(200, delta)
 
-    @freeze_time(datetime.datetime.fromtimestamp(1325376000))
+    @freeze_time(datetime.datetime.fromtimestamp(1325376000, tz=utc))
     def test_delta_start_end(self):
-        end = datetime.datetime.now() - datetime.timedelta(seconds=600)
-        end = time.mktime(end.timetuple())
-        start = datetime.datetime.now() - datetime.timedelta(seconds=800)
-        start = time.mktime(start.timetuple())
+        end = datetime.datetime.utcnow() - datetime.timedelta(seconds=600)
+        end = datetime.datetime.timestamp(end)
+        start = datetime.datetime.utcnow() - datetime.timedelta(seconds=800)
+        start = datetime.datetime.timestamp(start)
         start, end, delta = assemble_timerange(start, end, 5)
         eq_(1325375200.0, start)
         eq_(1325375400.0, end)


### PR DESCRIPTION
I found when trying to validate a PR locally that the tests were not
passing on the develop branch.  This should remove timezone
ambiguity by setting UTC everywhere in the tests.

I found also that `time.mktime(datetime.timetuple())` was an old
idiom for converting a datetime to a timestamp that had a new
replacement in `datetime.timestamp(datetime)`.