### PR TITLE
Apply the default query delta only when end, start, and delta are not set

### DIFF
--- a/datagrepper/app.py
+++ b/datagrepper/app.py
@@ -271,7 +271,9 @@ def raw():
     start = flask.request.args.get('start', None)
     end = flask.request.args.get('end', None)
     default_delta = app.config['DEFAULT_QUERY_DELTA']
-    delta = flask.request.args.get('delta', default_delta)
+    delta = flask.request.args.get('delta')
+    if not (start or end or delta):
+        delta = default_delta
     start, end, delta = assemble_timerange(start, end, delta)
 
     # Further filters, all ANDed together in CNF style.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -62,6 +62,42 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(kws['end'], expected_end)
 
     @patch('datagrepper.app.dm.Message.grep', return_value=(0, 0, []))
+    @patch.dict(datagrepper.app.app.config, {'DEFAULT_QUERY_DELTA': 180})
+    def test_raw_default_query_delta(self, grep):
+        resp = self.client.get('/raw')
+        self.assertEqual(resp.status_code, 200)
+        kws = grep.call_args[1]
+        # Verify the default query delta was applied
+        self.assertEqual((kws['end'] - kws['start']).total_seconds(), 180.0)
+
+    @patch('datagrepper.app.dm.Message.grep', return_value=(0, 0, []))
+    @patch.dict(datagrepper.app.app.config, {'DEFAULT_QUERY_DELTA': 180})
+    def test_raw_default_query_delta_with_start(self, grep):
+        resp = self.client.get('/raw?start=1564503781')
+        self.assertEqual(resp.status_code, 200)
+        kws = grep.call_args[1]
+        # Verify the default query delta was not applied
+        self.assertNotEqual((kws['end'] - kws['start']).total_seconds(), 180.0)
+
+    @patch('datagrepper.app.dm.Message.grep', return_value=(0, 0, []))
+    @patch.dict(datagrepper.app.app.config, {'DEFAULT_QUERY_DELTA': 180})
+    def test_raw_default_query_delta_with_end(self, grep):
+        resp = self.client.get('/raw?delta=7200')
+        self.assertEqual(resp.status_code, 200)
+        kws = grep.call_args[1]
+        # Verify the default query delta was not applied
+        self.assertEqual((kws['end'] - kws['start']).total_seconds(), 7200.0)
+
+    @patch('datagrepper.app.dm.Message.grep', return_value=(0, 0, []))
+    @patch.dict(datagrepper.app.app.config, {'DEFAULT_QUERY_DELTA': 180})
+    def test_raw_default_query_delta_with_delta(self, grep):
+        resp = self.client.get('/raw?end=1564503781')
+        self.assertEqual(resp.status_code, 200)
+        kws = grep.call_args[1]
+        # Verify the default query delta was not applied
+        self.assertNotEqual((kws['end'] - kws['start']).total_seconds(), 180.0)
+
+    @patch('datagrepper.app.dm.Message.grep', return_value=(0, 0, []))
     def test_raw_contains_without_delta(self, grep):
         """ https://github.com/fedora-infra/datagrepper/issues/206 """
         resp = self.client.get('/raw?category=wat&contains=foo')


### PR DESCRIPTION
This prevents a 500 error that occurs when the default delta is provided with start and/or end from the user.