### PR TITLE
implement default query delta

### DIFF
--- a/datagrepper/app.py
+++ b/datagrepper/app.py
@@ -50,7 +50,8 @@ from datagrepper.util import (
 
 app = flask.Flask(__name__)
 app.config.from_object("datagrepper.default_config")
-app.config.from_envvar("DATAGREPPER_CONFIG")
+if "DATAGREPPER_CONFIG" in os.environ:
+    app.config.from_envvar("DATAGREPPER_CONFIG")
 app.config["CORS_DOMAINS"] = list(map(re.compile, app.config.get("CORS_DOMAINS", [])))
 app.config["CORS_HEADERS"] = list(map(re.compile, app.config.get("CORS_HEADERS", [])))
 
@@ -279,11 +280,9 @@ def raw():
     # Perform our complicated datetime logic
     start = flask.request.args.get("start", None)
     end = flask.request.args.get("end", None)
-    default_delta = app.config["DEFAULT_QUERY_DELTA"]
     delta = flask.request.args.get("delta")
-    if not (start or end or delta):
-        delta = default_delta
-    start, end, delta = assemble_timerange(start, end, delta)
+    with app.app_context():
+        start, end, delta = assemble_timerange(start, end, delta)
 
     # Further filters, all ANDed together in CNF style.
     users = flask.request.args.getlist("user")
@@ -575,7 +574,8 @@ def make_charts(chart_type):
     start = flask.request.args.get("start", None)
     end = flask.request.args.get("end", None)
     delta = flask.request.args.get("delta", None)
-    start, end, delta = assemble_timerange(start, end, delta)
+    with app.app_context():
+        start, end, delta = assemble_timerange(start, end, delta)
 
     # Further filters, all ANDed together in CNF style.
     users = flask.request.args.getlist("user")

--- a/datagrepper/default_config.py
+++ b/datagrepper/default_config.py
@@ -3,5 +3,5 @@ CORS_DOMAINS = [".*"]
 CORS_METHODS = ["GET", "OPTIONS"]
 CORS_HEADERS = [".*"]
 CORS_MAX_AGE = "600"
-DEFAULT_QUERY_DELTA = None
+DEFAULT_QUERY_DELTA = 0
 DATANOMMER_SQLALCHEMY_URL = "postgresql://datanommer:datanommer@localhost/messages"

--- a/datagrepper/util.py
+++ b/datagrepper/util.py
@@ -8,9 +8,6 @@ from dateutil import tz
 from dateutil.parser import parse
 
 
-DEFAULT_DELTA_SECONDS = 600.0
-
-
 # http://flask.pocoo.org/snippets/45/
 # accept header returns json type content only
 # However, if the accept header is */*, then return json.
@@ -69,16 +66,24 @@ def assemble_timerange(start, end, delta):
     if delta is not None:
         delta = float(delta)
 
+    default_delta = float(flask.current_app.config["DEFAULT_QUERY_DELTA"])
+
     # Figure out values for unset arguments.
     valid_args = (start is not None, end is not None, delta is not None)
     if valid_args == (False, False, False):
-        pass
+        if default_delta >= 1:
+            end = now_seconds()
+            start = end - default_delta
+            delta = default_delta
     elif valid_args == (False, False, True):
         end = now_seconds()
         start = end - delta
     elif valid_args == (False, True, False):
-        delta = DEFAULT_DELTA_SECONDS
-        start = end - delta
+        if default_delta >= 1:
+            start = end - default_delta
+            delta = default_delta
+        else:
+            start = 0
     elif valid_args == (False, True, True):
         start = end - delta
     elif valid_args == (True, False, False):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,14 +2,11 @@
 # Copyright 2018 Mike Bonnet <mikeb@redhat.com>
 
 import json
-import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
-
-with patch.dict(os.environ, DATAGREPPER_CONFIG="/dev/null"):
-    import datagrepper.app
+import datagrepper.app
 
 
 class TestAPI(unittest.TestCase):
@@ -103,8 +100,7 @@ class TestAPI(unittest.TestCase):
         resp = self.client.get("/raw?end=1564503781")
         self.assertEqual(resp.status_code, 200)
         kws = grep.call_args[1]
-        # Verify the default query delta was not applied
-        self.assertNotEqual((kws["end"] - kws["start"]).total_seconds(), 180.0)
+        self.assertEqual((kws["end"] - kws["start"]).total_seconds(), 180.0)
 
     @patch("datagrepper.app.dm.Message.grep", return_value=(0, 0, []))
     def test_raw_default_query_with_start_and_end_native(self, grep):

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,14 +1,11 @@
 # SPDX-License-Identifier: GPL-2.0+
 # Copyright 2018 Mike Bonnet <mikeb@redhat.com>
 
-import os
 import re
 import unittest
 from unittest.mock import patch
 
-
-with patch.dict(os.environ, DATAGREPPER_CONFIG="/dev/null"):
-    import datagrepper.app
+import datagrepper.app
 
 
 class TestCORS(unittest.TestCase):


### PR DESCRIPTION
Implement the DEFAULT_QUERY_DELTA a little differently than the previous
implementation. This moves the majority of the logig into the utils, so
it can be reused in multiple places.

Resolves: #241

Signed-off-by: Ryan Lerch <rlerch@redhat.com>