### PR TITLE
Make the approximate message count work under timescaledb

### DIFF
--- a/datagrepper/app.py
+++ b/datagrepper/app.py
@@ -231,8 +231,8 @@ def count_all_messages():
     db.
     """
 
-    if app.config.get("DATAGREPPER_APPROXIMATE_COUNT", True):
-        query = "SELECT reltuples FROM pg_class WHERE relname = 'messages';"
+    if app.config.get("DATAGREPPER_APPROXIMATE_COUNT"):
+        query = "SELECT * FROM approximate_row_count('messages');"
         total = dm.session.execute(query).first()[0]
     else:
         total = dm.Message.grep(defer=True)[0]

--- a/datagrepper/default_config.py
+++ b/datagrepper/default_config.py
@@ -5,3 +5,4 @@ CORS_HEADERS = [".*"]
 CORS_MAX_AGE = "600"
 DEFAULT_QUERY_DELTA = None
 DATANOMMER_SQLALCHEMY_URL = "postgresql://datanommer:datanommer@localhost/messages"
+DATAGREPPER_APPROXIMATE_COUNT = True


### PR DESCRIPTION
The first thing this commit does is move the setting of the default
value of the DATAGREPPER_APPROXIMATE_COUNT config setting to the
default_config file rather than hard coding it in app.py

Secondly, this fixes the approximate count not working on timescaledb.
Previously we were calculating the approx number of messages with

SELECT reltuples FROM pg_class WHERE relname = 'messages';

as a workaround for slow actual counting of these rows when we have
millions of messages. However, this query does not work with
timescaledb, as reported in:

https://github.com/timescale/timescaledb/issues/525

and implemented in as the hypertable_approximate_row_count convenience
function in:

https://github.com/timescale/timescaledb/pull/539

ypertable_approximate_row_count was renamed to approximate_row_count()
in timescaledb 2.0, which is what is used in this commit.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>