### PR TITLE
make the feed on html use the default delta

### DIFF
--- a/datagrepper/templates/base.html
+++ b/datagrepper/templates/base.html
@@ -34,7 +34,7 @@
       <div class="container-narrow">
         <ul class="nav navbar-nav nav-justified nav-underline">
             <li class="nav-item"><a class="nav-link" href="{{ url_for('index') }}">Getting&nbsp;started</a></li>
-            <li class="nav-item active"><a class="nav-link" href="{{ url_for('raw') }}?rows_per_page=1&delta=127800">Feed</a></li>
+            <li class="nav-item active"><a class="nav-link" href="{{ url_for('raw') }}?rows_per_page=1">Feed</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('reference') }}">Reference</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('widget') }}">Embedding</a></li>
             <li class="nav-item"><a class="nav-link" href="https://github.com/fedora-infra/datagrepper">Source</a></li>


### PR DESCRIPTION
previously the link was hardcoded with a value of 127800. This commit
makes that link use the default delta value.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>