### PR TITLE
Add the downstream patch

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -228,7 +228,7 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.mimetype, "image/svg+xml")
         self.assertIn(
-            b'<svg xmlns:xlink="http://www.w3.org/1999/xlink"',
+            b'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"',
             resp.get_data(),
         )
 


### PR DESCRIPTION
There is a patch in downstream which does not seem to be fedora specific, so maybe it could be merged upstream. 

https://src.fedoraproject.org/rpms/datagrepper/blob/rawhide/f/datagrepper-0.9.5-fix-test.patch

Reason: For enabling Packit service on this repo we need to get rid of downstream patches,