### PR TITLE
Fix string formatting in test_api.py

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -227,8 +227,10 @@ class TestAPI(unittest.TestCase):
         resp = self.client.get("/charts/line")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.mimetype, "image/svg+xml")
-        svg_data = b'<svg xmlns="http://www.w3.org/2000/svg"\
-            xmlns:xlink="http://www.w3.org/1999/xlink"'
+        svg_data = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" '
+            b'xmlns:xlink="http://www.w3.org/1999/xlink"'
+        )
         # This bloc is to get rid of the downstream patch.
         # The output is different depending on lxml.
         try:


### PR DESCRIPTION
While doing `fedpkg mockbuild` the string was throwing an error. Fixed formatting and now it builds.