### PR TITLE
Modify .packit.yml not to change the spec file

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,6 +12,7 @@ files_to_sync:
 upstream_package_name: datagrepper
 # downstream (Fedora) RPM package name
 downstream_package_name: datagrepper
+sync_changelog: true
 
 srpm_build_deps:
   - poetry
@@ -28,6 +29,7 @@ actions:
        # we need poetry v1.1.7 because of a bug in 1.1.8 where python evaluates incorrectly
        - "sh -c 'wget https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py && python3 install-poetry.py --version 1.1.7'"
        - "rm install-poetry.py"
+   fix-spec-file: []
 
 jobs:
   - job: copr_build


### PR DESCRIPTION
While running `packit propose-downstream` keep the spec file as it is upstream.

`fix-spec-file: []` disables the changes packit does to spec file: https://packit.dev/docs/actions/#fix-spec-file
`sync_changelog`: https://packit.dev/docs/configuration/#sync_changelog