### PR TITLE
Release of 1.0.1

### DIFF
--- a/datagrepper.spec
+++ b/datagrepper.spec
@@ -1,6 +1,6 @@
 # https://bugzilla.redhat.com/show_bug.cgi?id=955781
 %global pypi_name datagrepper
-%global pypi_version 1.0.0
+%global pypi_version 1.0.1
 
 Name:           %{pypi_name}
 Version:        %{pypi_version}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datagrepper"
-version = "1.0.0"
+version = "1.0.1"
 description = "A webapp to query datanommer"
 authors = [
   "Fedora Infrastructure <admin@fedoraproject.org>"


### PR DESCRIPTION
It seems necessary to make a new release (1.0.1), because there had been changes in package versions (flask, flask-healthz, pygal and python-dateutil) and a new tarball needs to be generated.