### PR TITLE
Add a bunch of missing schemas

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2768,4 +2768,4 @@ schemas = ["anitya-schema", "bodhi-messages", "bugzilla2fedmsg-schema", "ci-mess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "22caf3cb1dfa5edbeb5b689483c43148eb62e044f87030ba91385eb1512967f7"
+content-hash = "311fab7b9554f7872fddd9ea35aac4ed21ee6d14ef5ec6383f6d6743c39cb1f1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,13 @@ fedora-messaging-git-hook-messages = {version = "*", optional = true}
 fedora-messaging-the-new-hotness-schema = {version = "*", optional = true}
 fedora-planet-messages = {version = "*", optional = true}
 fmn-messages = {version = "*", optional = true}
-kerneltest-messages = {version = "^1.0.0", optional = true}
-koji-fedoramessaging-messages = {version = "^1.2.2", optional = true}
+kerneltest-messages = {version = "*", optional = true}
+koji-fedoramessaging-messages = {version = "*", optional = true}
 koschei-messages = {version = "*", optional = true}
 maubot-fedora-messages = {version = "*", optional = true}
+mdapi-messages = {version = "*", optional = true}
 mediawiki-messages = {version = "*", optional = true}
 meetbot-messages = {version = "*", optional = true}
-mdapi-messages = {version = "*", optional = true}
 noggin-messages = {version = "*", optional = true}
 nuancier-messages = {version = "*", optional = true}
 pagure-messages = {version = "*", optional = true}


### PR DESCRIPTION
Not sure if this is a complete list or not, but they are mainly ones i have recently created, and the rest are the ones hosted on https://github.com/fedora-infra/ that werent here.

Note that https://github.com/fedora-infra/the-new-hotness-messages does exist, but doenst appear to ever been published to pypi, so didnt include that